### PR TITLE
Make a version that runs in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.6
+
+ADD ./src /src
+ADD ./entrypoint.sh /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@
 
 ## Clouddriver
 
-To generate an AWS Policy for Spinnaker Clouddriver:
+To generate an AWS Policy for the current head of Spinnaker Clouddriver:
+
+    ./bin/build
+    ./bin/run
+
+The policy will be printed to stdout. It will contain all of the necessary actions for Spinnaker's Clouddriver to operate. If you wish, you can isolate any of the actions to certain resources by modifying the policy after it is generated.
+
+### Running Locally
+
+If you have a checkout of Clouddriver locally and want to generate the policy for it you can run the python script directly on your development system:
 
     Run `src/generate.py <CLOUDDRIVER_AWS_DIRECTORY>`
 

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+set -e
+cd "$(dirname "$0")"/..
+
+IMAGE=spinnaker-aws-policy:runner
+docker build -t ${IMAGE} -f Dockerfile .

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+set -e
+cd "$(dirname "$0")"/..
+
+IMAGE=spinnaker-aws-policy:runner
+docker run --rm ${IMAGE}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+mkdir /spinnaker
+cd /spinnaker
+git clone https://github.com/spinnaker/clouddriver.git 1>&2
+/src/generate.py /spinnaker/clouddriver/clouddriver-aws


### PR DESCRIPTION
- default version checks out current Spinnaker clouddriver and runs
  against it
- keep the docs around for how to run locally